### PR TITLE
fix(docs): fix heading color on docs

### DIFF
--- a/examples/playground/src/_app/page.tsx
+++ b/examples/playground/src/_app/page.tsx
@@ -8,7 +8,7 @@ export default function Page() {
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="text-xl font-medium ">{homeT("title")}</h1>
+        <h1 className="text-xl font-medium text-white">{homeT("title")}</h1>
         <p className="mt-4 text-sm text-gray-300">{homeT("description")}</p>
       </div>
 


### PR DESCRIPTION
This PR fixes `<h1>` heading colors on docs by setting it to `text-white`.

Before:

<img width="1048" alt="image" src="https://github.com/user-attachments/assets/7661b50d-a0d7-4065-beab-c4e2e069628e" />

After:

<img width="950" alt="image" src="https://github.com/user-attachments/assets/f022cb76-def0-420f-b2bd-8b2fcbb3463e" />
