### PR TITLE
fix(package)/#111: Do not generate .prettierignore files to subdirs

### DIFF
--- a/package/src/cli/commands/generate/generateDistFiles.test.ts
+++ b/package/src/cli/commands/generate/generateDistFiles.test.ts
@@ -35,19 +35,11 @@ describe("generateOutDirs()", () => {
     generateOutDirs(LOCALIZED_DIR);
     expect(isDirectory(OUT_DIR)).toBe(true);
     expect(isFile(path.join(OUT_DIR, ".gitignore"))).toBe(true);
-    expect(isFile(path.join(OUT_DIR, ".prettierignore"))).toBe(true);
     expect(readFileSync(path.join(OUT_DIR, ".gitignore")).toString()).toBe("*");
-    expect(readFileSync(path.join(OUT_DIR, ".prettierignore")).toString()).toBe(
-      "*",
-    );
     expect(isDirectory(LOCALIZED_DIR)).toBe(true);
     expect(isFile(path.join(LOCALIZED_DIR, ".gitignore"))).toBe(true);
-    expect(isFile(path.join(LOCALIZED_DIR, ".prettierignore"))).toBe(true);
     expect(
       readFileSync(path.join(LOCALIZED_DIR, ".gitignore")).toString(),
-    ).toBe("*");
-    expect(
-      readFileSync(path.join(LOCALIZED_DIR, ".prettierignore")).toString(),
     ).toBe("*");
     expect(isFile(TYPES_DECLARATION_FILE)).toBe(true);
     expect(readFileSync(TYPES_DECLARATION_FILE).toString()).toBe(

--- a/package/src/cli/commands/generate/generateDistFiles.ts
+++ b/package/src/cli/commands/generate/generateDistFiles.ts
@@ -25,10 +25,8 @@ const schemaTemplate = "".concat(
 export function generateOutDirs(localizedDir: string) {
   makeDirectory(OUT_DIR);
   writeFileSync(path.join(OUT_DIR, ".gitignore"), "*");
-  writeFileSync(path.join(OUT_DIR, ".prettierignore"), "*");
   makeDirectory(localizedDir);
   writeFileSync(path.join(localizedDir, ".gitignore"), "*");
-  writeFileSync(path.join(localizedDir, ".prettierignore"), "*");
   generateDeclarationFile();
 }
 


### PR DESCRIPTION
Closes #111 

.prettierignore files work only on root level of the project. As so let's skip generating the files altogether. Documentation will be updated later to note that these files should be ignored from formatters.