### PR TITLE
Message types refactor

### DIFF
--- a/package/src/types/messages.ts
+++ b/package/src/types/messages.ts
@@ -87,12 +87,10 @@ type StripSpaces<S extends string> = RemoveAll<
  * @example "'{word}" -> "word}"
  * @example "foo '{word1} {word2}'" -> "foo "
  */
-type StripEscaped<S extends string> =
-  S extends `${infer Head}'${string}'${infer Tail}`
-    ? StripEscaped<`${Head}${Tail}`>
-    : S extends `${infer Head}'${string}${infer Tail}`
-      ? `${Head}${Tail}`
-      : S;
+type StripEscaped<S extends string> = RemoveAll<
+  RemoveAll<S, `'${string}'`>,
+  `'${string}`
+>;
 
 /**
  * Extract ICU message arguments ang tags from the given string.

--- a/package/src/types/messages.ts
+++ b/package/src/types/messages.ts
@@ -62,9 +62,10 @@ export type Message<
 type RemoveAll<
   S extends string,
   R extends string,
+  Acc extends string = "",
 > = S extends `${infer Head}${R}${infer Tail}`
-  ? RemoveAll<`${Head}${Tail}`, R>
-  : S;
+  ? RemoveAll<Tail, R, `${Acc}${Head}`>
+  : `${Acc}${S}`;
 
 /**
  * Utility type to remove all spaces and new lines from the provided string.

--- a/package/src/types/messages.ts
+++ b/package/src/types/messages.ts
@@ -57,14 +57,13 @@ export type Message<
     : never;
 
 /**
- * Utility type to replace a string with another.
+ * Utility type to remove a string from another.
  */
-type ReplaceAll<
+type RemoveAll<
   S extends string,
   R extends string,
-  W extends string,
 > = S extends `${infer Head}${R}${infer Tail}`
-  ? ReplaceAll<`${Head}${W}${Tail}`, R, W>
+  ? RemoveAll<`${Head}${Tail}`, R>
   : S;
 
 /**
@@ -73,17 +72,12 @@ type ReplaceAll<
 type StripWhitespace<S extends string> = StripSpaces<
   StripTabs<StripCarriageReturns<StripLineFeeds<S>>>
 >;
-type StripLineFeeds<S extends string> = ReplaceAll<S, "\n", "">;
-type StripCarriageReturns<S extends string> = ReplaceAll<S, "\r", "">;
-type StripTabs<S extends string> = ReplaceAll<
-  ReplaceAll<S, "\t\t", "">,
-  "\t",
-  ""
->;
-type StripSpaces<S extends string> = ReplaceAll<
-  ReplaceAll<ReplaceAll<S, "    ", "">, "  ", "">,
-  " ",
-  ""
+type StripLineFeeds<S extends string> = RemoveAll<S, "\n">;
+type StripCarriageReturns<S extends string> = RemoveAll<S, "\r">;
+type StripTabs<S extends string> = RemoveAll<RemoveAll<S, "\t\t">, "\t">;
+type StripSpaces<S extends string> = RemoveAll<
+  RemoveAll<RemoveAll<S, "    ">, "  ">,
+  " "
 >;
 
 /**

--- a/package/src/types/messages.ts
+++ b/package/src/types/messages.ts
@@ -18,7 +18,7 @@ export declare const messages: Messages;
 export type MessageKey = keyof Messages[Locale];
 
 /**
- * Utility type fot extractiong all the possible namespaces
+ * Utility type for extracting all the possible namespaces
  */
 type GetNamespaces<K extends string> = K extends `${infer N}.${infer R}`
   ? N | `${N}.${GetNamespaces<R>}`
@@ -93,7 +93,7 @@ type StripEscaped<S extends string> = RemoveAll<
 >;
 
 /**
- * Extract ICU message arguments ang tags from the given string.
+ * Extract ICU message arguments and tags from the given string.
  */
 type ExtractArgumentsAndTags<S extends string> =
   | ExtractArguments<S>


### PR DESCRIPTION
A small simplification of `ReplaceAll` to just `RemoveAll`, since that's the only use case.

I also added the accumulator, to avoid repeatedly scanning the input. I did not profile this for speed, but this does remain a tail-call, and it removes a corner case where trying to remove the empty string would loop forever (until TS gives up).

Lastly, wrote `StripEscaped` in terms of `ReplaceAll`, and fixed couple typos in comments.