### PR TITLE
Updated extractHrefOptions to support all types of link strings

### DIFF
--- a/package/src/router/shared/useHrefFactory.ts
+++ b/package/src/router/shared/useHrefFactory.ts
@@ -98,9 +98,47 @@ function withDomain(pathname: string, domain?: string) {
 
 export function extractHrefOptions<R extends Route>(args: UseHrefArgs<R>) {
   const [arg1, arg2, arg3] = args;
-  if (typeof arg1 === "object") return arg1;
+  if (typeof arg1 === "object") return checkStateAndExtract(arg1);
   const pathname = arg1;
   const params = typeof arg2 === "object" ? arg2 : undefined;
   const locale = typeof arg2 === "object" ? arg3 : arg2;
-  return { pathname, params, locale, query: undefined, hash: undefined };
+  return checkStateAndExtract({
+    pathname,
+    params,
+    locale,
+    query: undefined,
+    hash: undefined,
+  });
+}
+
+/**
+ * Extracts the hash and query params from the pathname and returns the pathname without the hash and query params.
+ * @param options - The options object containing the pathname, hash, and other options.
+ * @returns HrefOptions<Route> with hash and query params extracted from pathname if they exist.
+ */
+function checkStateAndExtract(options: HrefOptions<Route>): HrefOptions<Route> {
+  // Check for hash
+  const hashIndex = options.pathname.indexOf("#");
+  const hash =
+    hashIndex !== -1 ? options.pathname.slice(hashIndex + 1) : options.hash;
+  let pathname =
+    hashIndex !== -1 ? options.pathname.slice(0, hashIndex) : options.pathname;
+  // Check for query params
+  const queryIndex = options.pathname.indexOf("?");
+  let queryString: string | undefined;
+  if (queryIndex !== -1) {
+    queryString = pathname.slice(queryIndex + 1);
+    pathname = pathname.slice(0, queryIndex);
+  }
+  // Convert query string to Record<string, string> if needed
+  const query = queryString
+    ? Object.fromEntries(new URLSearchParams(queryString))
+    : options.query;
+  return {
+    pathname,
+    params: options.params,
+    locale: options.locale,
+    query,
+    hash,
+  };
 }


### PR DESCRIPTION
Updated the extractHrefOptions to support link components with href strings that include query params and fragments.

Before the following was not supported:

```tsx
<Link href="/#test">
```

You had to use a object:

```tsx
<Link href={{pathname: "/", hash: "test"}}>
```

The problem also effected query params.

But this pull request fixes that.